### PR TITLE
Fix: script modules lookup location

### DIFF
--- a/Mod Files/system/scripts/.modules/script.module.xbmcaddon/lib/xbmcaddon.py
+++ b/Mod Files/system/scripts/.modules/script.module.xbmcaddon/lib/xbmcaddon.py
@@ -45,6 +45,9 @@ class Addon:
                 locations.append(cwd)                            # current directory
                 locations.append("%s/%s" % (cwd, id))            # subdirectory in current directory
             locations.append("Q:\scripts\.modules\%s" % ( id ))  # script modules
+            
+            # XBMC for gamers stores script modules in system\scripts
+            locations.append("Q:\system\scripts\.modules\%s" % ( id )) 
 
             # plugin.music|video|etc.something addons
             if len( parts ) == 3 and parts[ 0 ] == "plugin":


### PR DESCRIPTION
Script modules in XBMC4GAMERS are stored in Q:\system\scripts\.modules rather than Q:\scripts\.modules as they are in vanilla XBMC4XBOX. Therefore, I have updated this script to also look for modules in this location.