### PR TITLE
Fix: DVD2XBOX Auto Install Game now finds xmbc.log

### DIFF
--- a/Mod Files/system/scripts/XBMC4Gamers/DVD2Xbox/default.py
+++ b/Mod Files/system/scripts/XBMC4Gamers/DVD2Xbox/default.py
@@ -18,7 +18,7 @@ if os.path.isfile("d:/default.xbe"):
 
 	# Gets current XBMC4Gamers directory.
 	CharCount = 100 # How many characters you want after 'The executable running is: '
-	with open(xbmc.translatePath("special://xbmc") + "xbmc.log", "r") as XBMCLOG:
+	with open(xbmc.translatePath("special://xbmc/system/") + "xbmc.log", "r") as XBMCLOG:
 		for line in XBMCLOG:
 			left,sep,right = line.partition("The executable running is: ")
 			if sep:


### PR DESCRIPTION
DVD2XBOX auto install script was unable to find the xbmc.log file, as its path was incorrect and this to determine what "The executable running is:" Without having the proper location of xbmc.log file, the script was unable to read said file in order to determine the XBMCPath, ultimately leading to the following error, in the xbmc.log itself (ironically.)

10:10:32 M: 31363072 NOTICE: -->Python Initialized<--
10:10:32 M: 30834688 ERROR: Error Type: <type 'exceptions.NameError'>
10:10:32 M: 30834688 ERROR: Error Contents: name 'XBMCPath' is not defined
10:10:32 M: 30830592 ERROR: Traceback (most recent call last):
File "Q:\system\scripts\XBMC4Gamers\DVD2Xbox\default.py", line 28, in
runself = XBMCPath # should point to XBMC
NameError: name 'XBMCPath' is not defined