### PR TITLE
Update default.py

### DIFF
--- a/Mod Files/system/scripts/XBMC4Gamers Extras/Synopsis/default.py
+++ b/Mod Files/system/scripts/XBMC4Gamers Extras/Synopsis/default.py
@@ -103,7 +103,7 @@ def synopsis_mode_video():
 			xbmc.executebuiltin('Skin.SetBool(SynopsisPreviewThere)')
 		elif PreviewFile.endswith('.strm'):
 			try:
-				urllib2.urlopen('http://www.google.com', timeout=1)
+				urllib2.urlopen('http://216.58.192.142', timeout=1) # google.com fixed IP to avoid DNS lookup. Will require maintainance.
 				Current_Window.setProperty( 'Player_Type','MPlayer' )
 				xbmc.executebuiltin('Skin.SetBool(SynopsisPreviewThere)')
 			except urllib2.URLError as err:


### PR DESCRIPTION
Unable to exit synopsis fix: 
DNS lookup can block for longer than 1 second when no internet connection is present,
causing urlopen to timeout (with no exception catch) and you can get stuck in the synopsis menu.
(.strm exists & no cable plugged in & several synopsis reads == stuck)